### PR TITLE
Fixing bug where @ symbol in command was not parsed correctly

### DIFF
--- a/serio
+++ b/serio
@@ -952,7 +952,7 @@ def main():
 			exit(EX_USAGE)
 
 		host_end = tmp_cmd_str.find(' ')
-		if '@' in tmp_cmd_str:
+		if '@' in tmp_cmd_str[0:host_end]:
 			# strip off leading [user@]
 			host_start = tmp_cmd_str.find('@') + 1
 		else:


### PR DESCRIPTION
Hi Frank,
I learned about this project at ELC this year and think it's great - thanks for sharing!

I found a small bug where commands with `@` in them resulted in an error if your host target did not contain an `@`. For example:
```
# ./sersh ttyUSB0 'systemctl status openvpn-client@client'
ERROR: [Errno 21] could not open port /dev/: [Errno 21] Is a directory: '/dev/'
```
This little fix should stop the host string search from going into the command string when parsing.

Cheers,
John